### PR TITLE
fix: variable_defs may be undefined

### DIFF
--- a/packages/cozeloop-ai/src/prompt/utils.ts
+++ b/packages/cozeloop-ai/src/prompt/utils.ts
@@ -38,8 +38,8 @@ export function formatPromptTemplate(
   if (!promptTemplate?.messages.length) {
     return [];
   }
-
-  const { messages, template_type, variable_defs } = promptTemplate;
+  // variable_defs may be undefined
+  const { messages, template_type, variable_defs = [] } = promptTemplate;
   const variableMap = buildVariableMap(variable_defs, variables);
   const formattedMessages: Message[] = [];
 


### PR DESCRIPTION
variable_defs这个数组服务器可能没返回导致buildVariableMap 中直接 for遍历这个对象时报错。
这可能不是一个最佳性能的修复方式，但是保证了最小代码修改和尽可能好的可阅读性。

```
function buildVariableMap(variableDefs, variables) {
  const variableMap = {};
  const variableKeys = new Set(Object.keys(variables || {}));
  for (const def of variableDefs) {
    if (!variableKeys.has(def.key)) {
      continue;
    }
    variableMap[def.key] = {
      def,
      value: variables?.[def.key]
    };
  }
  return variableMap;
}
```
